### PR TITLE
findvs: add support for MSVC detection on Windows Arm64

### DIFF
--- a/lib/findvs.js
+++ b/lib/findvs.js
@@ -20,6 +20,8 @@ const VS_VERSIONS_MODERN = new Map([
     msbuild:
       (process.arch === 'x64'
        ? path.join('MSBuild', 'Current', 'Bin', 'amd64', 'MSBuild.exe')
+       : process.arch === 'arm64'
+       ? path.join('MSBuild', 'Current', 'Bin', 'arm64', 'MSBuild.exe')
        : path.join('MSBuild', 'Current', 'Bin', 'MSBuild.exe')),
     toolset: 'v143',
   }],
@@ -27,6 +29,7 @@ const VS_VERSIONS_MODERN = new Map([
 const PACKAGES = {
   msbuild: /^Microsoft[.]VisualStudio[.]VC[.]MSBuild[.](?:v\d+[.])?Base$/i,
   vctools: /^Microsoft[.]VisualStudio[.]Component[.]VC[.]Tools[.]x86[.]x64$/i,
+  vctoolsArm64: /^Microsoft[.]VisualStudio[.]Component[.]VC[.]Tools[.]ARM64$/i,
   express: /^Microsoft[.]VisualStudio[.]WDExpress$/i,
   winsdk:
     /^Microsoft[.]VisualStudio[.]Component[.]Windows(81|10|11)SDK(?:[.](\d+)(?:[.]Desktop.*)?)?$/,
@@ -45,7 +48,7 @@ function checkRequiredPackages(packages) {
   for (const pkg of packages) {
     if (!foundMSBuild && PACKAGES.msbuild.test(pkg))
       foundMSBuild = true;
-    else if (!foundVCTools && PACKAGES.vctools.test(pkg))
+    else if (!foundVCTools && (PACKAGES.vctools.test(pkg) || PACKAGES.vctoolsArm64.test(pkg)))
       foundVCTools = true;
     else if (!foundExpress && PACKAGES.express.test(pkg))
       foundExpress = true;
@@ -83,7 +86,7 @@ function getSDKPaths(fullVer) {
   if (typeof fullVer !== 'string' || !fullVer)
     return;
   try {
-    const arch = (process.arch === 'ia32' ? 'x86' : 'x64');
+    const arch = (process.arch === 'ia32' ? 'x86' : process.arch);
     const shortVer = `v${/^\d+[.]\d+/.exec(fullVer)[0]}`;
     let verPath = getRegValue(`${SDK_REG}\\${shortVer}`, 'InstallationFolder');
     if (!verPath)
@@ -214,7 +217,7 @@ function findModernVS() {
             );
             clVer = readFileSync(vcVerFile, { encoding: 'utf8' }).trim();
           }
-          const arch = (process.arch === 'ia32' ? 'x86' : 'x64');
+          const arch = (process.arch === 'ia32' ? 'x86' : process.arch);
           let testPath = path.join(
             vsPath,
             'VC',

--- a/lib/findvs.js
+++ b/lib/findvs.js
@@ -20,16 +20,15 @@ const VS_VERSIONS_MODERN = new Map([
     msbuild:
       (process.arch === 'x64'
        ? path.join('MSBuild', 'Current', 'Bin', 'amd64', 'MSBuild.exe')
-       : process.arch === 'arm64'
-       ? path.join('MSBuild', 'Current', 'Bin', 'arm64', 'MSBuild.exe')
-       : path.join('MSBuild', 'Current', 'Bin', 'MSBuild.exe')),
+       : (process.arch === 'arm64'
+          ? path.join('MSBuild', 'Current', 'Bin', 'arm64', 'MSBuild.exe')
+          : path.join('MSBuild', 'Current', 'Bin', 'MSBuild.exe'))),
     toolset: 'v143',
   }],
 ]);
 const PACKAGES = {
   msbuild: /^Microsoft[.]VisualStudio[.]VC[.]MSBuild[.](?:v\d+[.])?Base$/i,
-  vctools: /^Microsoft[.]VisualStudio[.]Component[.]VC[.]Tools[.]x86[.]x64$/i,
-  vctoolsArm64: /^Microsoft[.]VisualStudio[.]Component[.]VC[.]Tools[.]ARM64$/i,
+  vctools: /^Microsoft[.]VisualStudio[.]Component[.]VC[.]Tools[.](x86[.]x64|ARM64)$/i,
   express: /^Microsoft[.]VisualStudio[.]WDExpress$/i,
   winsdk:
     /^Microsoft[.]VisualStudio[.]Component[.]Windows(81|10|11)SDK(?:[.](\d+)(?:[.]Desktop.*)?)?$/,
@@ -48,7 +47,7 @@ function checkRequiredPackages(packages) {
   for (const pkg of packages) {
     if (!foundMSBuild && PACKAGES.msbuild.test(pkg))
       foundMSBuild = true;
-    else if (!foundVCTools && (PACKAGES.vctools.test(pkg) || PACKAGES.vctoolsArm64.test(pkg)))
+    else if (!foundVCTools && PACKAGES.vctools.test(pkg))
       foundVCTools = true;
     else if (!foundExpress && PACKAGES.express.test(pkg))
       foundExpress = true;


### PR DESCRIPTION
Fixes #6 

With this fix, the `npm test` command passes, i.e. the native MSVC 2022 installation on my Windows Arm64 machine is found:
```
> npm test

> buildcheck@0.0.6 test
> node test/test.js

>>> Detected MSVS installations: [
  {
    path: 'C:\\Program Files\\Microsoft Visual Studio\\2022\\Community',
    version: { full: '17.14.36203.30', major: 17, minor: 14 },
    sdks: [
      {
        version: '10.0',
        fullVersion: '10.0.26100.0',
        includePaths: [
          'C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.26100.0\\shared',
          'C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.26100.0\\um',
          'C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.26100.0\\ucrt'
        ],
        libPaths: [
          'C:\\Program Files (x86)\\Windows Kits\\10\\Lib\\10.0.26100.0\\um\\arm64',
          'C:\\Program Files (x86)\\Windows Kits\\10\\Lib\\10.0.26100.0\\ucrt\\arm64'
        ]
      },
      {
        version: '10.0',
        fullVersion: '10.0.22621.0',
        includePaths: [
          'C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.22621.0\\shared',
          'C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.22621.0\\um',
          'C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.22621.0\\ucrt'
        ],
        libPaths: [
          'C:\\Program Files (x86)\\Windows Kits\\10\\Lib\\10.0.22621.0\\um\\arm64',
          'C:\\Program Files (x86)\\Windows Kits\\10\\Lib\\10.0.22621.0\\ucrt\\arm64'
        ]
      }
    ],
    year: 2022,
    msbuild: 'C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\MSBuild\\Current\\Bin\\arm64\\MSBuild.exe',
    toolset: 'v143',
    cl: 'C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.44.35207\\bin\\Hostarm64\\arm64\\cl.exe',
    includePaths: [
      'C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.44.35207\\include'
    ],
    libPaths: [
      'C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.44.35207\\lib\\arm64'
    ]
  }
]
>>> Using MSVS: 2022
>>> Using Windows SDK: 10.0.26100.0
```
